### PR TITLE
fix: ensure static asset cache-control headers are correctly applied for _next/static files

### DIFF
--- a/src/NextjsDistribution.ts
+++ b/src/NextjsDistribution.ts
@@ -217,7 +217,7 @@ export class NextjsDistribution extends Construct {
               override: false,
               // MDN Cache-Control Use Case: Caching static assets with "cache busting"
               // @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#caching_static_assets_with_cache_busting
-              value: `max-age=${Duration.days(365).toSeconds()}, immutable`,
+              value: `no-cache, no-store, must-revalidate, max-age=0`,
             },
           ],
         },

--- a/src/NextjsStaticAssets.ts
+++ b/src/NextjsStaticAssets.ts
@@ -116,8 +116,7 @@ export class NextjsStaticAssets extends Construct {
 
   private createBucketDeployment(asset: Asset) {
     const basePath = this.props.basePath?.replace(/^\//, ''); // remove leading slash (if present)
-    const allFiles = basePath ? `${basePath}/**/*` : '**/*';
-    const staticFiles = basePath ? `${basePath}/_next/static/**/*'` : '_next/static/**/*';
+    const staticFiles = '**/_next/static/**/*';
 
     return new NextjsBucketDeployment(this, 'BucketDeployment', {
       asset,
@@ -129,9 +128,6 @@ export class NextjsStaticAssets extends Construct {
       substitutionConfig: NextjsBucketDeployment.getSubstitutionConfig(this.buildEnvVars),
       prune: this.props.prune, // defaults to false
       putConfig: {
-        [allFiles]: {
-          CacheControl: 'public, max-age=0, must-revalidate',
-        },
         [staticFiles]: {
           CacheControl: 'public, max-age=31536000, immutable',
         },


### PR DESCRIPTION
- Fix glob pattern for static files to match relative paths
- Remove stray quote in staticFiles glob
- Ensure only _next/static files get long-term cache, all others get must-revalidate
- Prepares for CloudFront to use default 0s cache-control, only _next/static gets 1y immutable

Closes #static-cache-glob-bug